### PR TITLE
Switch to open crate to support all os

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,7 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
+ "open",
  "petgraph",
  "revm",
 ]
@@ -1494,6 +1495,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,6 +1757,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "open"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfabf1927dce4d6fdf563d63328a0a506101ced3ec780ca2135747336c98cef8"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "open-fastrlp"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +1853,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ lazy_static = "1.4.0"
 eyre = "0.6.7"
 itertools = "0.10"
 fnv = "1.0.7" # fast hashing for < 64 bytes. https://cglab.ca/~abeinges/blah/hash-rs/
+open = "5.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,9 +213,7 @@ fn main() {
             .arg(format!("{}/temp.svg", temp_dir.to_string_lossy()))
             .output()
             .expect("failed to execute process");
-        Command::new("open")
-            .arg(format!("{}/temp.svg", temp_dir.to_string_lossy()))
-            .spawn()
+        open::that(format!("{}/temp.svg", temp_dir.to_string_lossy()))
             .expect("failed to execute process");
     }
 }


### PR DESCRIPTION
Using `open-rs` to open file using associated application

I think it makes more sense to open file specified by output
for example it's confusing whether I specify output as `smth.dot` but the file that's getting opened is `/tmp/tmp.svg`
and in case I want to open png/svg I think dot can be removed as intermediary artifact